### PR TITLE
feat: Add circular time slider for duration inputs

### DIFF
--- a/style.css
+++ b/style.css
@@ -173,3 +173,55 @@ button.danger-btn { background-color: #c0392b; } /* Slightly adjusted danger col
 pre[class*="language-"] { margin: 0; border-radius: 0 0 var(--border-radius) var(--border-radius); font-family: 'Fira Code', monospace; font-size: 0.9em; max-height: 400px; }
 /* Prism Okaidia is already a dark theme, so it should work well.
    If adjustments are needed, they would be here, targeting .token classes */
+
+/* Circular Time Slider Styles */
+.time-slider-popup {
+    position: fixed; /* Use fixed to position relative to viewport, or absolute for relative to a positioned ancestor */
+    width: 200px;
+    height: 200px;
+    background-color: var(--surface-color);
+    border: 1px solid var(--border-color);
+    border-radius: 50%;
+    box-shadow: var(--shadow);
+    display: none; /* Hidden by default */
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    z-index: 1001; /* Above other elements */
+    user-select: none; /* Prevent text selection during drag */
+}
+
+.time-slider-track {
+    position: absolute;
+    width: 180px;
+    height: 180px;
+    border-radius: 50%;
+    border: 10px solid #69a0e8; /* Lighter shade of --primary-color (was --primary-color-light) */
+    box-sizing: border-box;
+}
+
+.time-slider-thumb {
+    position: absolute;
+    width: 20px;
+    height: 20px;
+    background-color: var(--primary-color);
+    border-radius: 50%;
+    transform-origin: 50% 50%;
+    cursor: pointer;
+    border: 2px solid white;
+    box-sizing: border-box;
+    /* Thumb will be positioned by JavaScript based on the center of the slider */
+}
+
+.time-slider-center-text {
+    font-family: 'Fira Code', monospace;
+    font-size: 1.5em;
+    color: var(--text-color);
+    text-align: center;
+}
+
+.time-slider-center-text span {
+    display: block;
+    font-size: 0.6em;
+    color: #aaa;
+}


### PR DESCRIPTION
Implemented a circular time slider that appears when users click on or focus time input fields within blocks (e.g., 'warten' block).

Features:
- Slider displays time in seconds and milliseconds.
- Dragging the slider updates the input field in real-time.
- Manual changes to the input field update the slider if it's open.
- Slider can be closed by clicking outside of it.
- Handles multiple time input blocks correctly.
- Includes basic off-screen positioning prevention.