### PR TITLE
Enhance time slider with snapping, markers, and UI improvements

### DIFF
--- a/style.css
+++ b/style.css
@@ -189,6 +189,8 @@ pre[class*="language-"] { margin: 0; border-radius: 0 0 var(--border-radius) var
     justify-content: center;
     z-index: 1001; /* Above other elements */
     user-select: none; /* Prevent text selection during drag */
+    backdrop-filter: blur(15px); /* Increased blur radius */
+    background-color: rgba(30, 30, 30, 0.75); /* Semi-transparent background for blur */
 }
 
 .time-slider-track {
@@ -198,17 +200,36 @@ pre[class*="language-"] { margin: 0; border-radius: 0 0 var(--border-radius) var
     border-radius: 50%;
     border: 10px solid #69a0e8; /* Lighter shade of --primary-color (was --primary-color-light) */
     box-sizing: border-box;
+    /* Ensure markers are drawn on top of the track border but below the thumb */
 }
+
+.time-slider-marker {
+    position: absolute;
+    background-color: var(--text-color); /* Or a specific marker color */
+    transform-origin: 0 50%; /* Rotate around the edge connected to the center */
+    z-index: 1; /* Below thumb (thumb is implicitly higher or set explicitly) */
+}
+
+.time-slider-marker.zero {
+    height: 15px; /* Larger marker for zero */
+    width: 3px;
+}
+
+.time-slider-marker.half-second {
+    height: 8px; /* Smaller marker for 0.5s intervals */
+    width: 1px;
+}
+
 
 .time-slider-thumb {
     position: absolute;
-    width: 20px;
-    height: 20px;
+    width: 30px; /* Increased size */
+    height: 30px; /* Increased size */
     background-color: var(--primary-color);
     border-radius: 50%;
     transform-origin: 50% 50%;
     cursor: pointer;
-    border: 2px solid white;
+    border: 3px solid white; /* Adjusted border for new size */
     box-sizing: border-box;
     /* Thumb will be positioned by JavaScript based on the center of the slider */
 }


### PR DESCRIPTION
- Implement snap-to-value at 0.5s intervals.
- Add a larger snap tolerance for the 0s mark.
- Increase the size of the slider thumb.
- Apply a blurred glass effect (backdrop-filter) to the slider popup and increased blur radius.
- Add visual markers on the slider track for 0.5s intervals and a larger marker for 0s.
- Center the slider popup horizontally under the input field.